### PR TITLE
Prevent duplicate loading API from keeping loading bar stuck

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1,4 +1,4 @@
-<!-- Version 1.0.63 | 893267f -->
+<!-- Version 1.0.64 | 3d13d4e -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -8328,7 +8328,7 @@ function handleCalendarTaskSelection(taskName) {
 
 var loadingBarHideTimer = null;
 
-function showLoadingBar() {
+function legacyShowLoadingBarFallback() {
     var loadingBarContainer = document.getElementById('loadingBarContainer');
     var loadingBar = document.getElementById('loadingBar');
     if (!loadingBarContainer || !loadingBar) return;
@@ -8345,11 +8345,11 @@ function showLoadingBar() {
 
     // Fallback auto-hide to prevent a stuck bar if a caller forgets to stop it
     loadingBarHideTimer = setTimeout(function(){
-        hideLoadingBar();
+        legacyHideLoadingBarFallback();
     }, 8000);
 }
 
-function hideLoadingBar() {
+function legacyHideLoadingBarFallback() {
     var loadingBarContainer = document.getElementById('loadingBarContainer');
     var loadingBar = document.getElementById('loadingBar');
     if (!loadingBarContainer || !loadingBar) return;


### PR DESCRIPTION
### Motivation
- The loading bar could remain visible after selecting a client because a second, later definition of the loading helpers in `Index.html` was shadowing the ref-counted loading controller used across the app.

### Description
- Renamed the later duplicate helpers to `legacyShowLoadingBarFallback` and `legacyHideLoadingBarFallback` so they no longer override the active `window.showLoadingBar` / `window.hideLoadingBar` API.
- Left the ref-counted loading controller (the canonical `window.showLoadingBar` / `window.hideLoadingBar`) intact and in use by autocomplete and client-loading flows.
- Updated the `Index.html` version header to `<!-- Version 1.0.64 | 3d13d4e -->` for traceability.

### Testing
- Searched the file to confirm only the ref-counted API remains bound to `showLoadingBar`/`hideLoadingBar` with `rg -n "^function showLoadingBar\(|^function hideLoadingBar\(|window\.showLoadingBar|window\.hideLoadingBar" Index.html` and verified the legacy names exist with `rg -n legacyShowLoadingBarFallback`.
- Verified current HEAD short hash with `git rev-parse --short HEAD` and committed the change with `git add Index.html && git commit -m "Fix stuck loading bar after client autocomplete selection"`.
- All automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea50c92100832ab9ebc23494a8a991)