### PR TITLE
Highlight 'MB' assigned notes for reassignment and bump version to 1.0.66

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1,4 +1,4 @@
-<!-- Version 1.0.65 | 4c2fc60 -->
+<!-- Version 1.0.66 | 9c5b71d -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -104,6 +104,7 @@
 
 
 #dashBody #recentList .item{display:flex;gap:10px;align-items:flex-start;padding:8px 6px;border-bottom:1px dashed #e5e7eb}
+#dashBody #recentList .item.mb-needs-assignment{background:#fff3b0;border-radius:8px}
 #dashBody #recentList .note{flex:1;white-space:pre-wrap;font-size:16px}
 #dashBody #recentList .meta{font-size:11px;color:#495057}
 #dashBody #recentList .assigned{font-weight:800;color:#0ca678}
@@ -1250,6 +1251,12 @@ function saveEditedNote(row, text, noteEl){
     items.forEach(it=>{
       const row=document.createElement('div');
       row.className='item';
+
+      // Highlight inbox rows assigned to MB so they can be reassigned to a real client.
+      const assignedValue = String(it.assigned || '').trim().toUpperCase();
+      if (assignedValue === 'MB') {
+        row.classList.add('mb-needs-assignment');
+      }
 
       // LEFT: note text
       const note=document.createElement('div');


### PR DESCRIPTION
### Motivation

- Surface inbox rows that are currently assigned to the placeholder `MB` so they stand out for reassignment and to improve UX when reviewing recent notes.

### Description

- Bumped the `Index.html` version comment to `1.0.66` and added a visual treatment by introducing the `.mb-needs-assignment` CSS rule and marking rows in `renderRecent` with `row.classList.add('mb-needs-assignment')` when `it.assigned` equals `MB`.

### Testing

- No automated tests were run for this small UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1131651b8832aa1e61cc9e40deacb)