### PR TITLE
Group pastWorks into dated blocks and highlight newest 3 notes

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -1,4 +1,4 @@
-<!-- Version 1.0.66 | 9c5b71d -->
+<!-- Version 1.0.67 | 53c9b1a -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -9540,19 +9540,18 @@ function displayClient(client, container) {
 
   clientDiv.appendChild(topRow);
 
-  var allC = [];
+  var allLines = [];
   (client.pastWorks || []).forEach(function(pw){
-    String(pw || '').split('\n').forEach(function(line){ var t = (line || '').trim(); if (t) allC.push(t); });
+    String(pw || '').split('\n').forEach(function(line){
+      allLines.push(String(line || ''));
+    });
   });
 
-  if (allC.length > 0) {
-    function parseMDY(line){ var m = String(line).match(/\b(\d{1,2})\/(\d{1,2})\/(\d{2,4})\b/); if (!m) return null; var mm=+m[1], dd=+m[2], yy=+m[3]; if (yy<100) yy+=2000; return new Date(yy, mm-1, dd); }
-    function safeFormatNoteHTML(s){ return typeof formatNoteHTML === 'function' ? formatNoteHTML(s) : String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
-
-    var withDates=[], noDates=[];
-    allC.forEach(function(line){ var d=parseMDY(line); if(d) withDates.push({line,d}); else noDates.push({line}); });
-    withDates.sort(function(a,b){ return a.d - b.d; });
-    var sorted = withDates.map(function(x){return x.line;}).concat(noDates.map(function(x){return x.line;}));
+  if (allLines.length > 0) {
+    // Match the loaded-client panel behavior:
+    // - Group lines into dated blocks with undated-line date inheritance
+    // - Keep only the newest 3 blocks visible/highlighted
+    var blocks = groupLinesIntoBlocks(allLines);
 
     var notesWrap = document.createElement('div');
     notesWrap.style.cssText = "display:flex; flex-direction:column; align-items:stretch; margin-top:5px; width:100%;";
@@ -9563,16 +9562,16 @@ function displayClient(client, container) {
     hiWrap.style.cssText = "display:flex; flex-direction:column; gap:5px;";
     notesWrap.appendChild(hiWrap);
 
-    var lastIdx = sorted.length - 1;
-    var hiCount = Math.min(3, sorted.length);
+    var lastIdx = blocks.length - 1;
+    var hiCount = Math.min(3, blocks.length);
     var firstHi = lastIdx - (hiCount - 1);
 
-    sorted.forEach(function(line, i){
+    blocks.forEach(function(block, i){
       var div = document.createElement('div');
       div.className = 'note-line';
       div.style.fontSize = '32px';
       div.style.marginBottom = '0px';
-      div.innerHTML = safeFormatNoteHTML(line);
+      div.innerHTML = renderBlockHTML(block);
       if (i >= firstHi) {
         div.classList.add('latest-note');
         div.style.backgroundColor = 'yellow';


### PR DESCRIPTION
### Motivation

- Improve how `client.pastWorks` lines are interpreted and displayed by grouping related lines into dated blocks and preserving undated-line inheritance.  
- Show the most recent context more clearly by highlighting the newest three blocks and attaching the client chip to the newest block.

### Description

- Bumped footer version comment to `1.0.67` and renamed `allC` to `allLines` when collecting `pastWorks` lines.  
- Replaced ad-hoc per-line date parsing and sorting with block-based logic using `groupLinesIntoBlocks` and `renderBlockHTML` to produce the note HTML.  
- Display logic now builds `blocks`, places the newest three blocks into `hiWrap` with a yellow highlight and hides older blocks in `olderWrap`, and appends the chip element to the latest block using `createChipElement`.  
- Removed local `parseMDY`/`safeFormatNoteHTML` sorting code and preserved mention handling via `attachMentionHandlers` for both visible and older note containers.

### Testing

- Ran unit tests with `npm test` and the test suite passed.  
- Ran linter with `npm run lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1156a5384832abe1126db4c9c992d)