### PR TITLE
Switch daily dashboard group text to Verizon MMS and add multipart safety guard

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,4 +1,4 @@
-// Version 1.0.59 | 4bf7050
+// Version 1.0.60 | 745eb97
 function doGet(e) {
   var userEmail = Session.getActiveUser().getEmail(); // Ensure it gets the active user
   Logger.log("Detected User Email: " + userEmail); // Debugging - logs detected email
@@ -2648,42 +2648,103 @@ function buildMbAssignmentLines_() {
   });
 }
 
-function buildDailyDashboardGroupText() {
+var DAILY_DASHBOARD_GROUP_RECIPIENTS = [
+  '8326215185@vzwpix.com',
+  '2817146370@vzwpix.com',
+  '8326216449@vzwpix.com'
+];
+
+var DAILY_DASHBOARD_SUBJECT = 'DAILY DASHBOARD';
+var DAILY_DASHBOARD_END_MARKER = 'END DAILY DASHBOARD';
+var DAILY_DASHBOARD_MAX_CHARS = 1200;
+
+function buildDailyDashboardSections_() {
   var dashboardSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('DASHBOARD 8.0');
   if (!dashboardSheet) throw new Error("Sheet 'DASHBOARD 8.0' not found");
 
   var rows = dashboardSheet.getDataRange().getValues().slice(1);
 
-  var jbLines = buildTwoClientSectionLines_(rows, 'JB');
-  var mbLines = buildMbAssignmentLines_();
-  var rbLines = buildTwoClientSectionLines_(rows, 'RB');
-  var teamLines = buildTeamTaskLines_(rows);
-
   return [
-    'JB 2 DASHBOARD CLIENTS:',
-    '',
-    jbLines.join('\n'),
-    '',
-    'MB DASHBOARD ASSIGNMENTS NEEDED:',
-    '',
-    mbLines.join('\n'),
-    '',
-    'RB 2 DASHBOARD CLIENTS:',
-    '',
-    rbLines.join('\n'),
-    '',
-    'TEAM TASKS:',
-    '',
-    teamLines.join('\n')
-  ].join('\n');
+    {
+      title: 'JB 2 DASHBOARD CLIENTS:',
+      lines: buildTwoClientSectionLines_(rows, 'JB')
+    },
+    {
+      title: 'MB DASHBOARD ASSIGNMENTS NEEDED:',
+      lines: buildMbAssignmentLines_()
+    },
+    {
+      title: 'RB 2 DASHBOARD CLIENTS:',
+      lines: buildTwoClientSectionLines_(rows, 'RB')
+    },
+    {
+      title: 'TEAM TASKS:',
+      lines: buildTeamTaskLines_(rows)
+    }
+  ];
+}
+
+function buildDailyDashboardGroupText() {
+  var sections = buildDailyDashboardSections_();
+  var sectionBlocks = sections.map(function(section) {
+    return [section.title, '', section.lines.join('\n')].join('\n');
+  });
+
+  return sectionBlocks.join('\n\n') + '\n\n' + DAILY_DASHBOARD_END_MARKER;
+}
+
+function buildDailyDashboardGroupTextParts_() {
+  var sections = buildDailyDashboardSections_();
+  var parts = [];
+  var currentPartSections = [];
+
+  sections.forEach(function(section) {
+    var nextSections = currentPartSections.concat([section]);
+    var partText = nextSections.map(function(item) {
+      return [item.title, '', item.lines.join('\n')].join('\n');
+    }).join('\n\n') + '\n\n' + DAILY_DASHBOARD_END_MARKER;
+
+    if (partText.length <= DAILY_DASHBOARD_MAX_CHARS || currentPartSections.length === 0) {
+      currentPartSections = nextSections;
+      return;
+    }
+
+    parts.push(currentPartSections.map(function(item) {
+      return [item.title, '', item.lines.join('\n')].join('\n');
+    }).join('\n\n') + '\n\n' + DAILY_DASHBOARD_END_MARKER);
+
+    currentPartSections = [section];
+  });
+
+  if (currentPartSections.length) {
+    parts.push(currentPartSections.map(function(item) {
+      return [item.title, '', item.lines.join('\n')].join('\n')
+    }).join('\n\n') + '\n\n' + DAILY_DASHBOARD_END_MARKER);
+  }
+
+  return parts;
 }
 
 function sendDailyDashboardGroupText() {
   var body = buildDailyDashboardGroupText();
-  MailApp.sendEmail({
-    to: '8326215185@vtext.com,2817146370@vtext.com,8326216449@vtext.com',
-    subject: 'DAILY DASHBOARD',
-    body: body
+  var recipients = DAILY_DASHBOARD_GROUP_RECIPIENTS.join(',');
+
+  if (body.length <= DAILY_DASHBOARD_MAX_CHARS) {
+    MailApp.sendEmail({
+      to: recipients,
+      subject: DAILY_DASHBOARD_SUBJECT,
+      body: body
+    });
+    return;
+  }
+
+  var parts = buildDailyDashboardGroupTextParts_();
+  parts.forEach(function(partBody, index) {
+    MailApp.sendEmail({
+      to: recipients,
+      subject: DAILY_DASHBOARD_SUBJECT + ' ' + (index + 1) + '/' + parts.length,
+      body: partBody
+    });
   });
 }
 


### PR DESCRIPTION
### Motivation
- The daily dashboard group text sent via Verizon SMS (`@vtext.com`) was truncating the body, so the sender should use Verizon MMS gateways and include a safety mechanism to detect or prevent silent chopping.
- The sender must preserve the existing dashboard sections and keep the daily 9 AM trigger behavior unchanged while providing a clear end marker or numbered multipart messages when needed.

### Description
- Replaced inline `@vtext.com` recipients with a centralized `DAILY_DASHBOARD_GROUP_RECIPIENTS` array using `@vzwpix.com` addresses and made `sendDailyDashboardGroupText()` send to `DAILY_DASHBOARD_GROUP_RECIPIENTS.join(',')`.
- Kept the base subject as `DAILY DASHBOARD` via `DAILY_DASHBOARD_SUBJECT` and appended numbered subjects (`DAILY DASHBOARD X/N`) when splitting into parts.
- Added an explicit `END DAILY DASHBOARD` marker to the body and a length guard `DAILY_DASHBOARD_MAX_CHARS = 1200`, plus logic to split messages by full section boundaries (never breaking a line) using `buildDailyDashboardGroupTextParts_()`.
- Preserved required sections (`JB 2 DASHBOARD CLIENTS`, `MB DASHBOARD ASSIGNMENTS NEEDED`, `RB 2 DASHBOARD CLIENTS`, `TEAM TASKS`), left `installDailyDashboardGroupTextTrigger()` unchanged (still creates only `sendDailyDashboardGroupText` at 9 AM), and kept `testBuildDailyDashboardGroupText()` as a preview/log and `testSendDailyDashboardGroupText()` as the immediate-send wrapper.
- Updated the `Code.gs` file header version to `// Version 1.0.60 | 745eb97` per repository header rules.

### Testing
- Ran pattern searches with `rg -n "sendDailyDashboardGroupText|buildDailyDashboardGroupText|installDailyDashboardGroupTextTrigger|testSendDailyDashboardGroupText|testBuildDailyDashboardGroupText|@vtext.com|@vzwpix.com|END DAILY DASHBOARD" Code.gs` and confirmed no `@vtext.com` remain and the new symbols are present; the search succeeded.
- Inspected the `Code.gs` diff to verify the new constants, section-building helpers, multipart splitting, and that `sendDailyDashboardGroupText()` uses the centralized recipients and subject; inspection showed the expected changes.
- Verified `installDailyDashboardGroupTextTrigger()` still creates only the `sendDailyDashboardGroupText` time-based trigger at 9 AM and that test helpers retain their original semantics; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f53a031c0832a9b44a34bfdf3add0)